### PR TITLE
Issue 445 - removes Email field from edit profile form.

### DIFF
--- a/apps/volontulo/forms.py
+++ b/apps/volontulo/forms.py
@@ -44,10 +44,6 @@ class EditProfileForm(forms.Form):
         max_length=128,
         required=False
     )
-    email = forms.EmailField(
-        label="Email",
-        required=True
-    )
     phone_no = forms.CharField(
         label=u"Numer telefonu",
         required=False

--- a/apps/volontulo/tests/views/test_usersprofile.py
+++ b/apps/volontulo/tests/views/test_usersprofile.py
@@ -159,7 +159,7 @@ class TestUsersProfile(TestCase):
         self.assertContains(response, u'Brzęczyszczykiewicz')
 
     def test__no_email_field_on_edit_profile_form(self):
-        u"""Test if Email field is not visible edit profile form"""
+        u"""Test if Email field is not visible edit profile form."""
 
         self.client.post('/login', {
             'email': u'volunteer1@example.com',

--- a/apps/volontulo/tests/views/test_usersprofile.py
+++ b/apps/volontulo/tests/views/test_usersprofile.py
@@ -144,9 +144,9 @@ class TestUsersProfile(TestCase):
         self.assertContains(response, u'333666999')
 
     def test__userprofile_first_and_last_name(self):
-        u"""Testing user profile page for filled first and last name."""
+        """Testing user profile page for filled first and last name."""
         self.client.post('/login', {
-            'email': u'volunteer1@example.com',
+            'email': 'volunteer1@example.com',
             'password': 'volunteer1',
         })
         response = self.client.get('/me')
@@ -155,14 +155,14 @@ class TestUsersProfile(TestCase):
         self.assertTemplateUsed(response, 'users/user_profile.html')
         # pylint: disable=no-member
         self.assertIn('profile_form', response.context)
-        self.assertContains(response, u'Grzegorz')
-        self.assertContains(response, u'Brzęczyszczykiewicz')
+        self.assertContains(response, 'Grzegorz')
+        self.assertContains(response, 'Brzęczyszczykiewicz')
 
     def test__no_email_field_on_edit_profile_form(self):
-        u"""Test if Email field is not visible edit profile form."""
+        """Test if Email field is not visible edit profile form."""
 
         self.client.post('/login', {
-            'email': u'volunteer1@example.com',
+            'email': 'volunteer1@example.com',
             'password': 'volunteer1',
         })
         response = self.client.get('/me')
@@ -171,4 +171,4 @@ class TestUsersProfile(TestCase):
         self.assertTemplateUsed(response, 'users/user_profile.html')
         # pylint: disable=no-member
         self.assertIn('profile_form', response.context)
-        self.assertNotContains(response, u'Email')
+        self.assertNotContains(response, 'Email')

--- a/apps/volontulo/tests/views/test_usersprofile.py
+++ b/apps/volontulo/tests/views/test_usersprofile.py
@@ -157,3 +157,18 @@ class TestUsersProfile(TestCase):
         self.assertIn('profile_form', response.context)
         self.assertContains(response, u'Grzegorz')
         self.assertContains(response, u'Brzęczyszczykiewicz')
+
+    def test__no_email_field_on_edit_profile_form(self):
+        u"""Test if Email field is not visible edit profile form"""
+
+        self.client.post('/login', {
+            'email': u'volunteer1@example.com',
+            'password': 'volunteer1',
+        })
+        response = self.client.get('/me')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'users/user_profile.html')
+        # pylint: disable=no-member
+        self.assertIn('profile_form', response.context)
+        self.assertNotContains(response, u'Email')

--- a/apps/volontulo/views/__init__.py
+++ b/apps/volontulo/views/__init__.py
@@ -85,7 +85,6 @@ def logged_user_profile(request):
         u"""Initialize EditProfileForm - helper method."""
         return EditProfileForm(
             initial={
-                'email': request.user.email,
                 'phone_no': request.user.userprofile.phone_no,
                 'first_name': request.user.first_name,
                 'last_name': request.user.last_name,


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/445
**Reference person:** @filipgorczynski
**Description:**

Removes Email field from Edit profile form.

**Unit Tests:**
- `apps/volontulo/tests/views/test_usersprofile.py`

**What tests do I need to run to validate this change:**
- `test__no_email_field_on_edit_profile_form`

Log in as volunteer user. In menu go to Profile. On this page Email field in "Profil" section should not be displayed.
