### PR TITLE
[issue-446] adds cookielaw JS code for hide notification (should work…

### DIFF
--- a/apps/volontulo/frontend/javascripts/cookielaw/js/cookielaw.js
+++ b/apps/volontulo/frontend/javascripts/cookielaw/js/cookielaw.js
@@ -1,0 +1,25 @@
+var Cookielaw = {
+
+    createCookie: function (name, value, days) {
+        var date = new Date(),
+            expires = '';
+        if (days) {
+            date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+            expires = "; expires=" + date.toGMTString();
+        } else {
+            expires = "";
+        }
+        document.cookie = name + "=" + value + expires + "; path=/";
+    },
+
+    createCookielawCookie: function () {
+        this.createCookie('cookielaw_accepted', '1', 10 * 365);
+
+        if (typeof (window.jQuery) === 'function') {
+            jQuery('#CookielawBanner').slideUp();
+        } else {
+            document.getElementById('CookielawBanner').style.display = 'none';
+        }
+    }
+
+};


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/446
**Reference person:** @filipgorczynski
**Description:**

Adds cookie law JavaScript file to frontend directory to use it when build with gulp.

**What tests do I need to run to validate this change:**

After release to production and build with gulp frontend/javascript/cookielaw/js/cookielaw.js should be copied to /static/cookielaw/js/cookielaw.js and notifcation closing should start work.
