### PR TITLE
Issue 458 "Sidebar block" is empty and visible

### DIFF
--- a/apps/volontulo/templates/organizations/organization_form.html
+++ b/apps/volontulo/templates/organizations/organization_form.html
@@ -1,4 +1,4 @@
-{% extends "common/col2.html" %}
+{% extends "common/col1.html" %}
 
 {% block title %}Tworzenie organizacji{% endblock %}
 

--- a/apps/volontulo/tests/views/test_create_orgranization.py
+++ b/apps/volontulo/tests/views/test_create_orgranization.py
@@ -146,3 +146,18 @@ class TestCreateOrganization(TestOrganizations):
         self.assertEqual(record.name, org_name)
         self.assertEqual(record.address, u'East Street 123')
         self.assertEqual(record.description, u'User unfriendly organization')
+
+    # pylint: disable=invalid-name
+    def test__create_organization_one_column_template(self):
+        """Test validate one column template on create page."""
+        # Disable for anonymous user
+        self.client.post('/login', {
+            'email': u'volunteer1@example.com',
+            'password': 'volunteer1',
+        })
+        response = self.client.get('/organizations/create')
+
+        self.assertTemplateUsed(
+            response,
+            'common/col1.html'
+        )


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/458
**Reference person:** @filipgorczynski
**Description:**

Changed layout to one column for creating organization page + unit tests.

**Unit Tests:**
- `apps/volontulo/tests/views/test_create_orgranization.py`
  and  method `test__create_organization_one_column_template`

Just enter to this page. Page /pages/site-news for now does not exists. Other pages in /pages/ directory already use one column layout.
