### PR TITLE
#504 Change text in homepage to Dolacz do jednej z ofert

### DIFF
--- a/apps/volontulo/templates/homepage.html
+++ b/apps/volontulo/templates/homepage.html
@@ -10,7 +10,7 @@
 {% endblock %}
 {% block content %}
     {% if offers %}
-        <h2>Pomóż w jednej z ofert:</h2>
+        <h2>Dołącz do jednej z ofert:</h2>
         <div class="row offer-thumbnails auto-clear">
         {% for o in offers %}
             {{ o.image }}


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/504
**Reference person:** @mdziergwa
**Description:** Change text in homepage into Dolacz do jednej z ofert

**New imports / dependencies:**
- `package`

**Unit Tests:**

**What tests do I need to run to validate this change:**
Have min one offer, go to home page and check if there is a headline Dolacz do jednej z ofert instead of Pomoz w jednej z ofert
