### PR TITLE
close #468, status in offers list

### DIFF
--- a/apps/volontulo/templates/organizations/organization_offers.html
+++ b/apps/volontulo/templates/organizations/organization_offers.html
@@ -8,6 +8,7 @@
             <th>Tytuł</th>
             <th>Miejsce</th>
             <th>Czas obowiązywania</th>
+            <th>Status</th>
             <th class="text-right"></th>
         </tr>
     {% for o in offers %}
@@ -29,6 +30,12 @@
                 <div class="form-control-static">
                     <span class="is-inline_block">{{ o.started_at|date:'j E Y, G:m'|default:' teraz' }}</span> -
                     <span class="is-inline_block">{{ o.finished_at|date:'j E Y, G:m'|default:' do ustalenia' }}</span>
+                </div>
+            </td>
+            <td>
+                <div class="form-control-static">
+                    {# <span class="is-inline_block">{{ Offer.OFFER_STATUS[o.offer_status].value | default:' unavailable'}}</span> #}
+                    <span class="is-inline_block">{% include 'common/labeled_status.html' with status=o.offer_status %}</span>
                 </div>
             </td>
             <td class="text-right">

--- a/apps/volontulo/tests/views/test_organizations.py
+++ b/apps/volontulo/tests/views/test_organizations.py
@@ -41,10 +41,11 @@ class TestOrganizations(TestCase):
 
     # pylint: disable=invalid-name
     def test__ensure_status_is_displayed_in_profile_view(self):
-        u"""Test if offer status is displayed in a profile view."""
+        """Test if offer status is displayed in a profile view."""
         self.client.login(
-            username=u'volunteer2@example.com', 
-            password=u'volunteer2')
+            username=u'volunteer2@example.com',
+            password=u'volunteer2'
+        )
         response = self.client.get('/me', follow=True)
         self.assertTemplateUsed(response, 'users/my_offers.html')
         # pylint: disable=no-member
@@ -55,10 +56,11 @@ class TestOrganizations(TestCase):
 
     # pylint: disable=invalid-name
     def test__ensure_status_is_displayed_in_organisations_view(self):
-        u"""Test if offer status is displayed in an organisation view."""
+        """Test if offer status is displayed in an organisation view."""
         self.client.login(
-            username=u'volunteer2@example.com', 
-            password=u'volunteer2')
+            username=u'volunteer2@example.com',
+            password=u'volunteer2'
+        )
         response = self.client.get('/me', follow=True)
         # pylint: disable=no-member
         self.assertIn('offers', response.context)

--- a/apps/volontulo/tests/views/test_organizations.py
+++ b/apps/volontulo/tests/views/test_organizations.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 
 from apps.volontulo.models import Organization
 from apps.volontulo.tests import common
+from django.utils.text import slugify
 
 
 class TestOrganizations(TestCase):
@@ -38,3 +39,22 @@ class TestOrganizations(TestCase):
         # pylint: disable=no-member
         self.assertIn('organizations', response.context)
         self.assertEqual(Organization.objects.all().count(), 2)
+
+    def test__ensure_status_is_displayedin_profile_view(self):
+        u"Test if offer status is displayed in a profile view."
+        self.client.login(
+            username=u'volunteer2@example.com', password=u'volunteer2')
+        response = self.client.get('/me', follow=True)
+        self.assertTemplateUsed(response, 'users/my_offers.html')
+        self.assertIn('offers', response.context)
+        self.assertEquals(
+            'published', response.context['offers'][0].offer_status)
+
+    def test__ensure_status_is_displayedin_organisations_view(self):
+        u"Test if offer status is displayed in an organisation view."
+        self.client.login(
+            username=u'volunteer2@example.com', password=u'volunteer2')
+        response = self.client.get('/me', follow=True)
+        self.assertIn('offers', response.context)
+        self.assertEquals(
+            'published', response.context['offers'][0].offer_status)

--- a/apps/volontulo/tests/views/test_organizations.py
+++ b/apps/volontulo/tests/views/test_organizations.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Organization
 from apps.volontulo.tests import common
-from django.utils.text import slugify
 
 
 class TestOrganizations(TestCase):
@@ -40,21 +39,27 @@ class TestOrganizations(TestCase):
         self.assertIn('organizations', response.context)
         self.assertEqual(Organization.objects.all().count(), 2)
 
-    def test__ensure_status_is_displayedin_profile_view(self):
+    # pylint: disable=invalid-name
+    def test__ensure_status_is_displayed_in_profile_view(self):
         u"Test if offer status is displayed in a profile view."
         self.client.login(
             username=u'volunteer2@example.com', password=u'volunteer2')
         response = self.client.get('/me', follow=True)
         self.assertTemplateUsed(response, 'users/my_offers.html')
+        # pylint: disable=no-member
         self.assertIn('offers', response.context)
+        # pylint: disable=no-member
         self.assertEquals(
             'published', response.context['offers'][0].offer_status)
 
-    def test__ensure_status_is_displayedin_organisations_view(self):
+    # pylint: disable=invalid-name
+    def test__ensure_status_is_displayed_in_organisations_view(self):
         u"Test if offer status is displayed in an organisation view."
         self.client.login(
             username=u'volunteer2@example.com', password=u'volunteer2')
         response = self.client.get('/me', follow=True)
+        # pylint: disable=no-member
         self.assertIn('offers', response.context)
+        # pylint: disable=no-member
         self.assertEquals(
             'published', response.context['offers'][0].offer_status)

--- a/apps/volontulo/tests/views/test_organizations.py
+++ b/apps/volontulo/tests/views/test_organizations.py
@@ -41,9 +41,10 @@ class TestOrganizations(TestCase):
 
     # pylint: disable=invalid-name
     def test__ensure_status_is_displayed_in_profile_view(self):
-        u"Test if offer status is displayed in a profile view."
+        u"""Test if offer status is displayed in a profile view."""
         self.client.login(
-            username=u'volunteer2@example.com', password=u'volunteer2')
+            username=u'volunteer2@example.com', 
+            password=u'volunteer2')
         response = self.client.get('/me', follow=True)
         self.assertTemplateUsed(response, 'users/my_offers.html')
         # pylint: disable=no-member
@@ -54,9 +55,10 @@ class TestOrganizations(TestCase):
 
     # pylint: disable=invalid-name
     def test__ensure_status_is_displayed_in_organisations_view(self):
-        u"Test if offer status is displayed in an organisation view."
+        u"""Test if offer status is displayed in an organisation view."""
         self.client.login(
-            username=u'volunteer2@example.com', password=u'volunteer2')
+            username=u'volunteer2@example.com', 
+            password=u'volunteer2')
         response = self.client.get('/me', follow=True)
         # pylint: disable=no-member
         self.assertIn('offers', response.context)


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/468
**Reference person:** @arjamizo
**Description:**

Add status column in table listing all the offers, both on `organisation` profile and `/me` page. 

**New imports / dependencies:**

**Unit Tests:**
- `apps/volontulo/tests/views/test_view_organization.py`

**What tests do I need to run to validate this change:**

```
python manage.py test apps.volontulo.tests.views.test_organizations --settings=volontulo_org.settings.dev 

test__ensure_status_is_displayedin_profile_view, 
test__ensure_status_is_displayedin_organisations_view
```
