### PR TITLE
#531 show only 'rekrutacja trwa' on offer details if no date is provided

### DIFF
--- a/apps/volontulo/templates/offers/show_offer.html
+++ b/apps/volontulo/templates/offers/show_offer.html
@@ -91,7 +91,7 @@
                     <a href="{% url "offers_join" offer.title|slugify offer.id %}" class="btn btn-default btn-lg">Zgłoś się na ten wolontariat</a>
                 </div>
                 <div class="panel-footer">
-                    Rekrutacja trwa do <b>{{offer.recruitment_end_date}}</b>
+                    Rekrutacja trwa {{offer.recruitment_end_date|date:'\d\o'|default:''}} <b>{{offer.recruitment_end_date|date:'j E Y, G:m'|default:''}}</b>
                 </div>
             </div>
             <div class="panel panel-default">


### PR DESCRIPTION
**Story / Bug id:** https://github.com/stxnext-csr/volontulo/issues/531
**Reference person:** @yog
**Description:**

on offer details, screen with not provided recrutation date and provided:
![image](https://cloud.githubusercontent.com/assets/432220/13368940/c4d786ba-dcef-11e5-8464-b2265036e316.png)
